### PR TITLE
Custom password option for crypt

### DIFF
--- a/rclone_sa_magic.py
+++ b/rclone_sa_magic.py
@@ -111,6 +111,9 @@ def parse_args():
     parser.add_argument('--cache', action="store_true",
                         help="for test: cache the remote destination.")
 
+    parser.add_argument('--password', type=str, default='autorclone',
+                        help='the password for crypt')
+
     args = parser.parse_args()
     return args
 
@@ -183,14 +186,16 @@ def gen_rclone_cfg(args):
 
             # For crypt destination
             if args.crypt:
+                password = subprocess.Popen(['rclone', 'obscure', args.password],
+                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 remote_name = '{}{:03d}'.format('dst', i + 1)
                 try:
                     fp.write('[{}_crypt]\n'
                              'type = crypt\n'
                              'remote = {}:\n'
                              'filename_encryption = standard\n'
-                             'password = hfSJiSRFrgyeQ_xNyx-rwOpsN2P2ZHZV\n'
-                             'directory_name_encryption = true\n\n'.format(remote_name, remote_name))
+                             'password = {}\n'
+                             'directory_name_encryption = true\n\n'.format(remote_name, remote_name, password))
                 except:
                     sys.exit("failed to write {} to {}".format(args.destination_id, output_of_config_file))
 

--- a/rclone_sa_magic.py
+++ b/rclone_sa_magic.py
@@ -99,6 +99,8 @@ def parse_args():
 
     parser.add_argument('-c', '--rclone_config_file', type=str,
                         help='config file path of rclone')
+    parser.add_argument('-n', '--custom_config_name', type=str,
+                        help='custom name for generated rclone config file')
     parser.add_argument('-test', '--test_only', action="store_true",
                         help='for test: make rclone print some more information.')
     parser.add_argument('-t', '--dry_run', action="store_true",
@@ -120,9 +122,12 @@ def parse_args():
     return args
 
 
-def gen_rclone_cfg(args):
+def gen_rclone_cfg(args, custom_name):
     sa_files = glob.glob(os.path.join(args.service_account, '*.json'))
-    output_of_config_file = './rclone.conf'
+    if custom_name:
+        output_of_config_file = './{}.conf'.format(custom_name)
+    else:    
+        output_of_config_file = './rclone.conf'
 
     if len(sa_files) == 0:
         sys.exit('No json files found in ./{}'.format(args.service_account))
@@ -264,7 +269,7 @@ def main():
     config_file = args.rclone_config_file
     if config_file is None:
         print('generating rclone config file.')
-        config_file, end_id = gen_rclone_cfg(args)
+        config_file, end_id = gen_rclone_cfg(args, args.custom_config_name)
         print('rclone config file generated.')
     else:
         return print('not supported yet.')

--- a/rclone_sa_magic.py
+++ b/rclone_sa_magic.py
@@ -111,7 +111,7 @@ def parse_args():
     parser.add_argument('--cache', action="store_true",
                         help="for test: cache the remote destination.")
 
-    parser.add_argument('--password', type=str, default='autorclone',
+    parser.add_argument('-ps', '--password', type=str, default='autorclone',
                         help='the password for crypt')
 
     args = parser.parse_args()


### PR DESCRIPTION
Users can use the -ps flag to indicate a specific password for crypt use.
Utilizes ``rclone obscure`` to create compatible encrypted passwords to add to crypt configurations.
Default password if not indicated is "autorclone"